### PR TITLE
Add llama3 example

### DIFF
--- a/examples/llama3/Modelfile
+++ b/examples/llama3/Modelfile
@@ -1,0 +1,1 @@
+FROM llama3


### PR DESCRIPTION
It's not currently possible to pull a model (as the default model download location is not writeable), and it's useful for testing to generate an image with the model already downloaded (even if `OLLAMA_TMPDIR` is set to a writeable location in the future).